### PR TITLE
add cohort era mode to cohort occurrence sql

### DIFF
--- a/ClinicalCharacteristics.Rproj
+++ b/ClinicalCharacteristics.Rproj
@@ -1,5 +1,4 @@
 Version: 1.0
-ProjectId: c5515530-e5e6-4414-a711-95dbd2ef079d
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/R/R6Class.R
+++ b/R/R6Class.R
@@ -514,7 +514,8 @@ TableShell <- R6::R6Class("TableShell",
             target_cohort_table = buildOptions$targetCohortTempTable,
             cohort_occurrence_table = buildOptions$cohortOccurrenceTempTable,
             time_window_table = buildOptions$timeWindowTempTable,
-            work_database_schema = executionSettings$workDatabaseSchema
+            work_database_schema = executionSettings$workDatabaseSchema,
+            use_era = buildOptions$useCohortEra
           ) |>
           SqlRender::translate(
             targetDialect = executionSettings$getDbms(),
@@ -616,6 +617,7 @@ BuildOptions <- R6::R6Class(
     #' @param patientLevelTableShellTempTable the name of the patient level data table with additional meta info used in execution. Defaults as a temp table #pat_ts_tab
     #' @param categoricalSummaryTempTable the name of the categorical summary table used in execution. Defaults as a temp table #categorical_table
     #' @param continuousSummaryTempTable the name of the continuous summary table used in execution. Defaults as a temp table #continuous_table
+    #' @param useCohortEra a true false toggle specifying if in a cohort Char whether to use the cohort era (TRUE) or just the start date (FALSE)
     initialize = function(codesetTempTable = NULL,
                           sourceCodesetTempTable = NULL,
                           timeWindowTempTable = NULL,
@@ -626,7 +628,8 @@ BuildOptions <- R6::R6Class(
                           patientLevelDataTempTable = NULL,
                           patientLevelTableShellTempTable = NULL,
                           categoricalSummaryTempTable = NULL,
-                          continuousSummaryTempTable = NULL
+                          continuousSummaryTempTable = NULL,
+                          useCohortEra = NULL
                           ) {
       .setString(private = private, key = ".codesetTempTable", value = codesetTempTable)
       .setString(private = private, key = ".sourceCodesetTempTable", value = sourceCodesetTempTable)
@@ -639,6 +642,7 @@ BuildOptions <- R6::R6Class(
       .setString(private = private, key = ".patientLevelTableShellTempTable", value = patientLevelTableShellTempTable)
       .setString(private = private, key = ".categoricalSummaryTempTable", value = categoricalSummaryTempTable)
       .setString(private = private, key = ".continuousSummaryTempTable", value = continuousSummaryTempTable)
+      .setLogical(private = private, key = ".useCohortEra", value = useCohortEra)
     }
   ),
   private = list(
@@ -652,7 +656,8 @@ BuildOptions <- R6::R6Class(
     .patientLevelDataTempTable = NULL,
     .patientLevelTableShellTempTable = NULL,
     .categoricalSummaryTempTable = NULL,
-    .continuousSummaryTempTable = NULL
+    .continuousSummaryTempTable = NULL,
+    .useCohortEra = NULL
   ),
 
   active = list(
@@ -710,6 +715,11 @@ BuildOptions <- R6::R6Class(
     #' @field continuousSummaryTempTable table name for continuous summary table
     continuousSummaryTempTable = function(value) {
       .setActiveString(private = private, key = ".continuousSummaryTempTable", value = value)
+    },
+
+    #' @field useCohortEra toggle to choose if using cohort era or start date
+    useCohortEra = function(value) {
+      .setActiveLogical(private = private, key = ".useCohortEra", value = value)
     }
   )
 )
@@ -1785,12 +1795,12 @@ CohortLineItem <- R6::R6Class(
     #' @param covariateCohort a CohortInfo class with cohorts for covariates
     #' @param timeInterval a time interval class object to determine the time frame to consider the analytic
     #' @param statistic a Statistic Class object used to determine what type of analytic should be done for the line item
-    initialize = function(
-    sectionLabel,
-    domainTable,
-    covariateCohort,
-    timeInterval,
-    statistic
+   initialize = function(
+      sectionLabel,
+      domainTable,
+      covariateCohort,
+      timeInterval,
+      statistic
     ) {
       super$initialize(
         sectionLabel = sectionLabel,
@@ -1803,7 +1813,6 @@ CohortLineItem <- R6::R6Class(
       )
       # add cohortInfo class object
       .setClass(private = private, key = "covariateCohort", value = covariateCohort, class = "CohortInfo")
-
     }
   ),
   private = list(

--- a/R/R6Wrappers.R
+++ b/R/R6Wrappers.R
@@ -94,7 +94,7 @@ createExecutionSettings <- function(connectionDetails,
 #' @param patientLevelTableShellTempTable the name of the patient level data table with additional meta info used in execution. Defaults as a temp table #pat_ts_tab
 #' @param categoricalSummaryTempTable the name of the categorical summary table used in execution. Defaults as a temp table #categorical_table
 #' @param continuousSummaryTempTable the name of the continuous summary table used in execution. Defaults as a temp table #continuous_table
-#'
+#' @param useCohortEra a true false toggle specifying if in a cohort Char whether to use the cohort era (TRUE) or just the start date (FALSE)
 #' @return A BuildOptions object
 #' @export
 defaultTableShellBuildOptions <- function(codesetTempTable = "#codeset",
@@ -107,7 +107,8 @@ defaultTableShellBuildOptions <- function(codesetTempTable = "#codeset",
                                           patientLevelDataTempTable = "#patient_data",
                                           patientLevelTableShellTempTable = "#pat_ts_tab",
                                           categoricalSummaryTempTable = "#categorical_table",
-                                          continuousSummaryTempTable = "#continuous_table"
+                                          continuousSummaryTempTable = "#continuous_table",
+                                          useCohortEra = TRUE
                                           ) {
 
   buildOpts <- BuildOptions$new(
@@ -121,7 +122,8 @@ defaultTableShellBuildOptions <- function(codesetTempTable = "#codeset",
     patientLevelDataTempTable = patientLevelDataTempTable,
     patientLevelTableShellTempTable = patientLevelTableShellTempTable,
     categoricalSummaryTempTable = categoricalSummaryTempTable,
-    continuousSummaryTempTable = continuousSummaryTempTable
+    continuousSummaryTempTable = continuousSummaryTempTable,
+    useCohortEra = useCohortEra
   )
   return(buildOpts)
 
@@ -764,7 +766,6 @@ newConceptBreaks <- function(name, breaks, labels) {
 #' @param statistic The Statistic object to be used to evaluate the line item
 #' @param cohort A CohortInfo object
 #' @param timeInterval The TimeInterval object used for the line item
-#'
 #' @return A CohortLineItem object
 #'
 #' @export

--- a/inst/sql/cohortOccurrenceQuery.sql
+++ b/inst/sql/cohortOccurrenceQuery.sql
@@ -23,6 +23,13 @@ INNER JOIN (
   FROM @time_window_table tt
   WHERE time_label IN ('{time_labels}')
 ) tw
+{{@use_era}} ?
+{{
 ON DATEADD(day, tw.time_a, t.cohort_start_date) <= ch.cohort_end_date
   AND DATEADD(day, tw.time_b, t.cohort_start_date) >= ch.cohort_start_date
+}} : {{
+ON ch.cohort_start_date >= DATEADD(day, tw.time_a, t.cohort_start_date)
+  AND ch.cohort_start_date <= DATEADD(day, tw.time_b, t.cohort_start_date)
+  AND ch.cohort_start_date <= t.cohort_end_date
+}}
 ;

--- a/man/BuildOptions.Rd
+++ b/man/BuildOptions.Rd
@@ -30,6 +30,8 @@ An R6 class to define build options for the tableShell
 \item{\code{categoricalSummaryTempTable}}{table name for categorical summary table}
 
 \item{\code{continuousSummaryTempTable}}{table name for continuous summary table}
+
+\item{\code{useCohortEra}}{toggle to choose if using cohort era or start date}
 }
 \if{html}{\out{</div>}}
 }
@@ -56,7 +58,8 @@ An R6 class to define build options for the tableShell
   patientLevelDataTempTable = NULL,
   patientLevelTableShellTempTable = NULL,
   categoricalSummaryTempTable = NULL,
-  continuousSummaryTempTable = NULL
+  continuousSummaryTempTable = NULL,
+  useCohortEra = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -84,6 +87,8 @@ An R6 class to define build options for the tableShell
 \item{\code{categoricalSummaryTempTable}}{the name of the categorical summary table used in execution. Defaults as a temp table #categorical_table}
 
 \item{\code{continuousSummaryTempTable}}{the name of the continuous summary table used in execution. Defaults as a temp table #continuous_table}
+
+\item{\code{useCohortEra}}{a true false toggle specifying if in a cohort Char whether to use the cohort era (TRUE) or just the start date (FALSE)}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/defaultTableShellBuildOptions.Rd
+++ b/man/defaultTableShellBuildOptions.Rd
@@ -15,7 +15,8 @@ defaultTableShellBuildOptions(
   patientLevelDataTempTable = "#patient_data",
   patientLevelTableShellTempTable = "#pat_ts_tab",
   categoricalSummaryTempTable = "#categorical_table",
-  continuousSummaryTempTable = "#continuous_table"
+  continuousSummaryTempTable = "#continuous_table",
+  useCohortEra = TRUE
 )
 }
 \arguments{
@@ -38,6 +39,8 @@ defaultTableShellBuildOptions(
 \item{categoricalSummaryTempTable}{the name of the categorical summary table used in execution. Defaults as a temp table #categorical_table}
 
 \item{continuousSummaryTempTable}{the name of the continuous summary table used in execution. Defaults as a temp table #continuous_table}
+
+\item{useCohortEra}{a true false toggle specifying if in a cohort Char whether to use the cohort era (TRUE) or just the start date (FALSE)}
 
 \item{connectionDetails}{A DatabaseConnector connectionDetails object (optional if connection is specified)}
 }


### PR DESCRIPTION
- add toggle to have cohort era mode
- in buildOptions if useCohortEra = TRUE uses cohort era in cohort occurrence query

```
ON DATEADD(day, tw.time_a, t.cohort_start_date) <= ch.cohort_end_date
  AND DATEADD(day, tw.time_b, t.cohort_start_date) >= ch.cohort_start_date
```
- if useCohortEra = FALSE uses start date in cohort occurrence query

```
ON ch.cohort_start_date >= DATEADD(day, tw.time_a, t.cohort_start_date)
  AND ch.cohort_start_date <= DATEADD(day, tw.time_b, t.cohort_start_date)
  AND ch.cohort_start_date <= t.cohort_end_date
```
- default is TRUE