### PR TITLE
Issue 62 - Fixes for using connection instead of connectionDetails

### DIFF
--- a/R/R6Class.R
+++ b/R/R6Class.R
@@ -735,7 +735,8 @@ ExecutionSettings <- R6::R6Class(
                           cohortTable = NULL,
                           cdmSourceName = NULL) {
       stopifnot(is.null(connectionDetails) || is.null(connection))
-      .setClass(private = private, key = "connectionDetails", value = connectionDetails, class = "ConnectionDetails")
+      .setClass(private = private, key = "connectionDetails", value = connectionDetails,
+                class = "ConnectionDetails", nullable = TRUE)
       .setClass(private = private, key = ".connection", value = connection,
                 class = "DatabaseConnectorJdbcConnection", nullable = TRUE)
       .setString(private = private, key = ".cdmDatabaseSchema", value = cdmDatabaseSchema)
@@ -746,7 +747,12 @@ ExecutionSettings <- R6::R6Class(
     },
     #' @description extract the dbms dialect
     getDbms = function() {
-      dbms <- private$connectionDetails$dbms
+      conObj <- private$.connection
+      if (!is.null(conObj)) {
+        dbms <- conObj@dbms
+      } else {
+        dbms <- private$connectionDetails$dbms
+      }
       return(dbms)
     },
     #' @description connect to dbms


### PR DESCRIPTION
Fix to ExecutionSettings initialize() to allow null values for both connection and connectionDetails objects. We do check that 1 and only 1 is fulfilled earlier.

Fix to ExecutionSettings getDbms() to allow for connection object use.