### PR TITLE
change adherent to left side inclusive

### DIFF
--- a/inst/sql/aggregate/denom.sql
+++ b/inst/sql/aggregate/denom.sql
@@ -30,7 +30,8 @@ FROM (
                       on t.subject_id = OP.person_id and t.cohort_start_date >= OP.observation_period_start_date and t.cohort_start_date <= op.observation_period_end_date
                     CROSS JOIN @time_window tw
                 ) a
-                WHERE DATEADD(day, a.time_a, a.cohort_start_date) >= a.observation_period_start_date AND DATEADD(day, a.time_b, a.cohort_start_date) <= a.cohort_end_date
+                -- Ensure patient has fulfilled observation period and left side of time interval to be in denom
+                WHERE DATEADD(day, a.time_a, a.cohort_start_date) >= a.observation_period_start_date AND DATEADD(day, a.time_a, a.cohort_start_date) <= a.cohort_end_date
             ) b
             GROUP BY b.cohort_definition_id, b.time_label
   ) cd


### PR DESCRIPTION
ClinChar uses a stat called adherent count. This counts the number of events in the interval the same way as observed count. However the denominator is different. 

Before the denominator from adherent count was taking all patients that had observation over the entire interval length. Now we make the denominator those who have satisfied at least a day more than the left side of the time interval. 