### PR TITLE
Source concept set object type concepts bug

### DIFF
--- a/R/R6Wrappers.R
+++ b/R/R6Wrappers.R
@@ -471,8 +471,8 @@ createSourceConceptSetLineItem <- function(sectionLabel = NA_character_,
     domainTable = domain,
     sourceConceptSet = sourceConceptSet,
     timeInterval = timeInterval,
-    statistic = statistic,
-    typeConceptIds = typeConceptIds
+    statistic = statistic#,
+    #typeConceptIds = typeConceptIds
   )
   return(scsDefinition)
 
@@ -515,8 +515,8 @@ createSourceConceptSetLineItemBatch <- function(sectionLabel,
       statistic = statistic,
       domain = domain,
       sourceConceptSet = .x,
-      timeInterval = .y,
-      typeConceptIds = typeConceptIds
+      timeInterval = .y#,
+      #typeConceptIds = typeConceptIds
     )
   ) |>
     unname()


### PR DESCRIPTION
The source concept set functions have a type concepts param, but the class does not. I'm not sure if it's supposed to or not - but either way the functions and class should be consistent.

I saw this line commented out so was not sure if the fix should be to the functions or to the class: https://github.com/OHDSI/ClinicalCharacteristics/blame/main/R/R6Class.R#L1703

For now I just commented out the params to get it working.